### PR TITLE
Speed up improvement for laserOdometry and scanRegister (20%)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ catkin_package(
   INCLUDE_DIRS include
 )
 
+add_definitions( -march=native )
 
 add_executable(scanRegistration src/scanRegistration.cpp)
 target_link_libraries(scanRegistration ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBS})

--- a/src/laserOdometry.cpp
+++ b/src/laserOdometry.cpp
@@ -136,13 +136,9 @@ void TransformToEnd(PointType const * const pi, PointType * const po)
   Vector3 v2 = rotateX( v1, -rx );
   Vector3 v3 = rotateY( v2, -ry );
 
-  rx = transform_rot_X;
-  ry = transform_rot_Y;
-  rz = transform_rot_Z;
-
-  Vector3 v4 = rotateY( v3, ry );
-  Vector3 v5 = rotateX( v4, rx );
-  Vector3 v6 = rotateZ( v5, rz );
+  Vector3 v4 = rotateY( v3, transform_rot_Y );
+  Vector3 v5 = rotateX( v4, transform_rot_X );
+  Vector3 v6 = rotateZ( v5, transform_rot_Z );
   v6 += transform_pos - imuShiftFromStart;
 
   Vector3 v7 = rotateZ( v6, imuRollStart );
@@ -763,11 +759,15 @@ int main(int argc, char** argv)
           transform_pos.x() += matX.at<float>(3, 0);
           transform_pos.y() += matX.at<float>(4, 0);
           transform_pos.z() += matX.at<float>(5, 0);
-// TODO
-//          for(int i=0; i<6; i++){
-//            if(isnan(transform[i]))
-//              transform[i]=0;
-//          }
+
+          if( isnan(transform_rot_X.value()) ) transform_rot_X = Angle();
+          if( isnan(transform_rot_Y.value()) ) transform_rot_Y = Angle();
+          if( isnan(transform_rot_Z.value()) ) transform_rot_Z = Angle();
+
+          if( isnan(transform_pos.x()) ) transform_pos.x() = 0.0;
+          if( isnan(transform_pos.y()) ) transform_pos.y() = 0.0;
+          if( isnan(transform_pos.z()) ) transform_pos.z() = 0.0;
+
           float deltaR = sqrt(
                               pow(rad2deg(matX.at<float>(0, 0)), 2) +
                               pow(rad2deg(matX.at<float>(1, 0)), 2) +

--- a/src/math_utils.h
+++ b/src/math_utils.h
@@ -1,0 +1,111 @@
+#ifndef MATH_UTILS_H
+#define MATH_UTILS_H
+
+#include <pcl/point_types.h>
+
+
+class Vector3 : public Eigen::Vector4f
+{
+public:
+
+    Vector3(float x, float y, float z):Eigen::Vector4f(x,y,z,0) {}
+
+    Vector3(void):Eigen::Vector4f(0,0,0,0) {}
+
+    template<typename OtherDerived>
+    Vector3(const Eigen::MatrixBase<OtherDerived>& other)
+        : Eigen::Vector4f(other)
+    { }
+
+    template<typename OtherDerived>
+    Vector3& operator=(const Eigen::MatrixBase <OtherDerived>& other)
+    {
+        this->Eigen::Vector4f::operator=(other);
+        return *this;
+    }
+
+    Vector3(const pcl::PointXYZI& p):Eigen::Vector4f( p.x, p.y, p.z,0) {}
+
+    Vector3& operator=(const pcl::PointXYZI& point)
+    {
+        x() = point.x;
+        y() = point.y;
+        z() = point.z;
+        return *this;
+    }
+
+    float x() const { return (*this)(0); }
+    float y() const { return (*this)(1); }
+    float z() const { return (*this)(2); }
+
+    float& x() { return (*this)(0); }
+    float& y() { return (*this)(1); }
+    float& z() { return (*this)(2); }
+};
+
+class Angle{
+public:
+    Angle():
+        _ang(0.0),
+        _cos(1.0),
+        _sin(0.0) {}
+
+    Angle(float value):
+        _ang(value),
+        _cos(std::cos(value)),
+        _sin(std::sin(value)) {}
+
+    Angle( const Angle& other ):
+        _ang( other._ang ),
+        _cos( other._cos ),
+        _sin( other._sin ) {}
+
+    void operator =( const Angle& other)
+    {
+        _ang = ( other._ang );
+        _cos = ( other._cos );
+        _sin = ( other._sin );
+    }
+    Angle operator-() const
+    {
+        Angle out;
+        out._ang = _ang;
+        out._cos = _cos;
+        out._sin = -(_sin);
+        return out;
+    }
+
+    float value() const { return _ang; }
+
+    float cos() const { return _cos; }
+
+    float sin() const { return _sin; }
+
+private:
+    float _ang, _cos, _sin;
+};
+
+
+inline Vector3 rotateX(const Vector3& v,const Angle& ang)
+{
+    return Vector3( v.x(),
+                    ang.cos() * v.y() - ang.sin() * v.z(),
+                    ang.sin() * v.y() + ang.cos() * v.z() );
+}
+
+inline Vector3 rotateY(const Vector3& v,const Angle& ang)
+{
+    return Vector3( ang.cos() * v.x() + ang.sin() * v.z(),
+                    v.y(),
+                   -ang.sin() * v.x() + ang.cos() * v.z() );
+}
+
+inline Vector3 rotateZ(const Vector3& v,const Angle& ang)
+{
+    return Vector3( ang.cos() * v.x() - ang.sin() * v.y(),
+                    ang.sin() * v.x() + ang.cos() * v.y(),
+                    v.z() );
+}
+
+
+#endif // MATH_UTILS_H

--- a/src/scanRegistration.cpp
+++ b/src/scanRegistration.cpp
@@ -588,7 +588,6 @@ void imuHandler(const sensor_msgs::Imu::ConstPtr& imuIn)
   imuYaw[imuPointerLast] = yaw;
   imuAcc[imuPointerLast] = acc;
 
-
   AccumulateIMUShift();
 }
 


### PR DESCRIPTION
Hi,

this PR bring a roughly 20%-25% reduction in CPU usage to laserOdometry and scanRegister.

I think that the most significant contribution, though is the simplification of the code, that is considerably more readable, thanks to the class Vector3 inherited from Eigen::Vector4f (note, I used Vector4f to enable vectorization).

I must confess that using Eigen don't bring much performance improvement. What really makes a difference is that we don't waste time calculating over and over again the std::cos and std::sin of the same angle.


