### PR TITLE
Extracted some magic constants and made them configurable.

### DIFF
--- a/launch/loam_velodyne.launch
+++ b/launch/loam_velodyne.launch
@@ -2,7 +2,8 @@
 
   <arg name="rviz" default="true" />
 
-  <node pkg="loam_velodyne" type="scanRegistration" name="scanRegistration" output="screen"/>
+  <node pkg="loam_velodyne" type="scanRegistration" name="scanRegistration" output="screen">
+  </node>
 
   <node pkg="loam_velodyne" type="laserOdometry" name="laserOdometry" output="screen" respawn="true">
   </node>


### PR DESCRIPTION
Extracted:
- the number of feature regions per scan
- the size of the curvature region
- the maximum number of sharp / less sharp corner points per feature region
- the maximum number of flat surface points per feature region
- the surface curvature threshold below / above which a point is considered a flat / corner point
- the voxel size used in filtering less flat surface points

into global variables and made them configurable via ros parameters.

Default values are the same, no changes to the logic.