### PR TITLE
Fixed optimization bug under degeneracy

### DIFF
--- a/src/lib/BasicLaserMapping.cpp
+++ b/src/lib/BasicLaserMapping.cpp
@@ -848,6 +848,9 @@ void BasicLaserMapping::optimizeTransformTobeMapped()
       matAtB = matAt * matB;
       matX = matAtA.colPivHouseholderQr().solve(matAtB);
 
+      // NOTE: Handling with the degeneracy problem according to the paper
+      // J. Zhang, M. Kaess and S. Singh, "On degeneracy of optimization-based state estimation problems,"
+      // 2016 IEEE International Conference on Robotics and Automation (ICRA), Stockholm, 2016
       if (iterCount == 0)
       {
          Eigen::Matrix<float, 1, 6> matE;
@@ -877,7 +880,7 @@ void BasicLaserMapping::optimizeTransformTobeMapped()
                break;
             }
          }
-         matP = matV.inverse() * matV2;
+         matP = matV2 * matV.inverse();
       }
 
       if (isDegenerate)

--- a/src/lib/BasicLaserOdometry.cpp
+++ b/src/lib/BasicLaserOdometry.cpp
@@ -558,6 +558,9 @@ void BasicLaserOdometry::process()
 
          matX = matAtA.colPivHouseholderQr().solve(matAtB);
 
+         // NOTE: Handling with the degeneracy problem according to the paper
+         // J. Zhang, M. Kaess and S. Singh, "On degeneracy of optimization-based state estimation problems,"
+         // 2016 IEEE International Conference on Robotics and Automation (ICRA), Stockholm, 2016
          if (iterCount == 0)
          {
             Eigen::Matrix<float, 1, 6> matE;
@@ -587,7 +590,7 @@ void BasicLaserOdometry::process()
                   break;
                }
             }
-            matP = matV.inverse() * matV2;
+            matP = matV2 * matV.inverse();
          }
 
          if (isDegenerate)


### PR DESCRIPTION
According to the paper, **"J. Zhang, M. Kaess and S. Singh, On degeneracy of optimization-based state estimation problems, 2016 IEEE International Conference on Robotics and Automation (ICRA), Stockholm, 2016"**, when **degeneracy** happens, the update should be remapped by "matV.inverse() * matV2".

However, in the original paper Vu and Vf are transposed matrix of eigenvalues, which should correspond to matV2 and matV in the current implementation a4c364a677647f2a35831439032dc5a58378b3fd.

Thus, to update the states towards well-conditioned directions only, "matV.transpose().inverse() * matV2.transpose()" should be used, or equivalently "matV2 * matV.inverse()".