### PR TITLE
Windows build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_conversions)
 
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common filters)
 
 include_directories(
   include

--- a/include/loam_velodyne/common.h
+++ b/include/loam_velodyne/common.h
@@ -65,9 +65,8 @@ inline void publishCloudMsg(ros::Publisher& publisher,
 // ROS time adapters
 inline Time fromROSTime(ros::Time const& rosTime)
 {
-  auto epoch = std::chrono::system_clock::time_point();
   auto since_epoch = std::chrono::seconds(rosTime.sec) + std::chrono::nanoseconds(rosTime.nsec);
-  return epoch + since_epoch;
+  return Time() + since_epoch;
 }
 
 inline ros::Time toROSTime(Time const& time_point)

--- a/include/loam_velodyne/time_utils.h
+++ b/include/loam_velodyne/time_utils.h
@@ -5,7 +5,8 @@
 namespace loam
 { 
   /** \brief A standard non-ROS alternative to ros::Time.*/
-  using Time = std::chrono::system_clock::time_point;
+  using Time =
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
 
   // helper function
   inline double toSec(Time::duration duration)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(loam
+add_library(loam STATIC
             math_utils.h
             ScanRegistration.cpp
             BasicScanRegistration.cpp

--- a/src/lib/LaserMapping.cpp
+++ b/src/lib/LaserMapping.cpp
@@ -223,7 +223,7 @@ void LaserMapping::imuHandler(const sensor_msgs::Imu::ConstPtr& imuIn)
    tf::Quaternion orientation;
    tf::quaternionMsgToTF(imuIn->orientation, orientation);
    tf::Matrix3x3(orientation).getRPY(roll, pitch, yaw);
-   updateIMU({ fromROSTime(imuIn->header.stamp) , roll, pitch });
+   updateIMU({ fromROSTime(imuIn->header.stamp) , static_cast<float>(roll), static_cast<float>(pitch) });
 }
 
 void LaserMapping::spin()


### PR DESCRIPTION
- use nanosecond precision for time points explicitly
- build loam as static lib
- explicit cast of double RPY to float Angle
- use only needed components of pcl