### PR TITLE
Fix compilation error on Ubuntu 18.04 (ROS Melodic)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1.3)
 project(loam_velodyne)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -29,7 +29,8 @@ catkin_package(
 
 ## Compile as C++14, supported in ROS Kinetic and newer
 # set_property(TARGET invz_player PROPERTY CXX_STANDARD 17)
-add_compile_options(-std=c++14)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_definitions( -march=native )
 


### PR DESCRIPTION
Fixes #102. Seems 3.1.3 is the [oldest version](https://cmake.org/cmake/help/v3.1/prop_tgt/CXX_STANDARD.html) that supports this option (I couldn't find that option in CMake [3.0.0](https://cmake.org/cmake/help/v3.0/manual/cmake-properties.7.html)). Personally I think it's safe to assume that people using Ubuntu 16.04 have CMake 3.1.3 or higher, since 3.2.2 [was released in 2015](https://launchpad.net/ubuntu/+source/cmake/3.3.2-1ubuntu1) for Xenial.