### PR TITLE
Fix bug in eigenvalues classifying points

### DIFF
--- a/src/lib/BasicLaserMapping.cpp
+++ b/src/lib/BasicLaserMapping.cpp
@@ -684,14 +684,14 @@ void BasicLaserMapping::optimizeTransformTobeMapped()
                Vector3 a = Vector3(_laserCloudCornerFromMap->points[pointSearchInd[j]]) - vc;
 
                mat_a(0, 0) += a.x() * a.x();
-               mat_a(0, 1) += a.x() * a.y();
-               mat_a(0, 2) += a.x() * a.z();
+               mat_a(1, 0) += a.x() * a.y();
+               mat_a(2, 0) += a.x() * a.z();
                mat_a(1, 1) += a.y() * a.y();
-               mat_a(1, 2) += a.y() * a.z();
+               mat_a(2, 1) += a.y() * a.z();
                mat_a(2, 2) += a.z() * a.z();
             }
             matA1 = mat_a / 5.0;
-
+            // This solver only looks at the lower-triangular part of matA1.
             Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> esolver(matA1);
             matD1 = esolver.eigenvalues().real();
             matV1 = esolver.eigenvectors().real();


### PR DESCRIPTION
Eigen::SelfAdjointEigenSolver docs say: Only the lower triangular part of the input matrix is referenced.
The original code was filling the upper triangular part. 
As a result, the obtained eigenvalues were actually... the diagonal elements, while totally ignoring their correlation. 

In practice: the original code was not doing its job while classifying point patches that were not at 90 degrees with the (arbitrary) XYZ axes.

Closes #118 